### PR TITLE
Mantenimiento 2024-10-23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -54,7 +54,7 @@ jobs:
         php-versions: ['8.1', '8.2', '8.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -67,7 +67,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -82,7 +82,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -95,7 +95,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          extensions: sqlite3, iconv, zip
           coverage: none
           tools: composer:v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -86,7 +86,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,18 +47,18 @@ jobs:
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
   phpunit:
-    name: Tests on PHP ${{ matrix.php-versions }} (phpunit)
+    name: Tests on PHP ${{ matrix.php-version }} (phpunit)
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -28,7 +28,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -38,7 +38,7 @@ jobs:
       - name: Create code coverage
         run: vendor/bin/phpunit --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: build/coverage
@@ -73,7 +73,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
@@ -86,7 +86,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -94,7 +94,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage
           path: build/coverage

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -79,7 +79,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.20.0" installed="3.20.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.22" installed="1.10.22" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.64.0" installed="3.64.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.10.3" installed="3.10.3" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.10.3" installed="3.10.3" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.12.7" installed="1.12.7" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 - 2023 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2017 - 2024 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,9 @@
         "phpunit/phpunit": "^9.5",
         "dms/phpunit-arraysubset-asserts": "^0.4.0",
         "guzzlehttp/guzzle": "^7.7",
-        "symfony/browser-kit": "^6.3",
-        "symfony/http-client": "^6.3",
-        "symfony/mime": "^6.3"
+        "symfony/browser-kit": "^6.3|^7.1",
+        "symfony/http-client": "^6.3|^7.1",
+        "symfony/mime": "^6.3|^7.1"
     },
     "suggest": {
         "guzzlehttp/guzzle": "Perform the download process using Guzzle",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "dms/phpunit-arraysubset-asserts": "^0.4.0",
+        "dms/phpunit-arraysubset-asserts": "^0.5.0",
         "guzzlehttp/guzzle": "^7.7",
         "symfony/browser-kit": "^6.3|^7.1",
         "symfony/http-client": "^6.3|^7.1",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Se da mantenimiento a los archivos de documentación y de desarrollo del proyect
 
 - Se actualiza el archivo de licencia a 2024.
 - Se actualiza la configuración de `php-cs-fixer` por que la regla `function_typehint_space` fue deprecada.
+- Se agrega la compatibilidad con Symfony 7.x en desarrollo.
 - En los flujos de trabajo de GitHub:
   - Se agrega PHP 8.3 a la matriz de pruebas.
   - Se usa PHP 8.3 para los trabajos.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Se da mantenimiento a los archivos de documentación y de desarrollo del proyect
 - Se actualiza el archivo de licencia a 2024.
 - Se actualiza la configuración de `php-cs-fixer` por que la regla `function_typehint_space` fue deprecada.
 - Se agrega la compatibilidad con Symfony 7.x en desarrollo.
+- Se actualiza la librería `dms/phpunit-arraysubset-asserts` en desarrollo a la versión `0.5.0`.
 - En los flujos de trabajo de GitHub:
   - Se agrega PHP 8.3 a la matriz de pruebas.
   - Se usa PHP 8.3 para los trabajos.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 **This document is in spanish**
 
+## Mantenimiento 2024-10-23
+
+Se da mantenimiento a los archivos de documentación y de desarrollo del proyecto:
+
+- Se actualiza el archivo de licencia a 2024.
+- Se actualiza la configuración de `php-cs-fixer` por que la regla `function_typehint_space` fue deprecada.
+- En los flujos de trabajo de GitHub:
+  - Se agrega PHP 8.3 a la matriz de pruebas.
+  - Se usa PHP 8.3 para los trabajos.
+  - Se actualizan las acciones de GitHub a la versión 4.
+  - Se cambia la variable `php-version` a singular.
+  - Se agrega la configuración extensiones al ejecutar el trabajo `phpunit` pues falla en `nektos/act`.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 4.0.0 2023-06-30
 
 El proyecto tiene cambios menores en la descarga, pero que rompen la compatibilidad.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3,6 +3,7 @@
 For next major release:
 
 - [ ] Remove empty constructor for `Eclipxe\SepomexPhp\Downloader\PhpStreamsDownloader`.
+- [ ] Use dedicated exceptions.
 
 Include more options like:
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,9 @@
 # SepomexPHP To Do List
 
+For next major release:
+
+- [ ] Remove empty constructor for `Eclipxe\SepomexPhp\Downloader\PhpStreamsDownloader`.
+
 Include more options like:
 
 - [ ] Search states by name

--- a/src/Downloader/PhpStreamsDownloader.php
+++ b/src/Downloader/PhpStreamsDownloader.php
@@ -12,6 +12,7 @@ final class PhpStreamsDownloader implements DownloaderInterface
 
     public function __construct()
     {
+        // if empty, remove on next major release
     }
 
     public function downloadTo(string $destinationFile): void


### PR DESCRIPTION
Se da mantenimiento a los archivos de documentación y de desarrollo del proyecto:

- Se actualiza el archivo de licencia a 2024.
- Se actualiza la configuración de `php-cs-fixer` por que la regla `function_typehint_space` fue deprecada.
- Se agrega la compatibilidad con Symfony 7.x en desarrollo.
- Se actualiza la librería `dms/phpunit-arraysubset-asserts` en desarrollo a la versión `0.5.0`.
- En los flujos de trabajo de GitHub:
  - Se agrega PHP 8.3 a la matriz de pruebas.
  - Se usa PHP 8.3 para los trabajos.
  - Se actualizan las acciones de GitHub a la versión 4.
  - Se cambia la variable `php-version` a singular.
  - Se agrega la configuración extensiones al ejecutar el trabajo `phpunit` pues falla en `nektos/act`.
- Se actualizan las herramientas de desarrollo.